### PR TITLE
Allow static linking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,18 @@ readme = "README.md"
 
 [build-dependencies]
 bindgen = { version = "^0.53.1", optional = true }
-cc = { version = "^1.0.50", features = ["parallel"], optional = true }
-cmake = { version  = "^0.1.42", optional = true }
-pkg-config = { version = "^0.3.17", optional = true }
+cc = { version = "^1.0.50", features = ["parallel"]}
+glob = "^0.3"
+cmake = "^0.1.42"
+pkg-config = "^0.3.17"
 lazy_static = "^1.4.0"
 
 [features]
 default = []
-buildtime-bindgen = ["bindgen", "cc", "cmake", "pkg-config"]
+buildtime-bindgen = ["bindgen"]
+
+# The source location and build method (cmake, direct cc, link system library)
+# is selected by environment variable. Cargo features are not used because these
+# are additive and can set by the package(s) that depend on apriltag-sys. (By
+# this same logic, we should remove buildtime-bindgen feature and make it an
+# environment variable.)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ Import `apriltag-sys` dependency in your `Cargo.toml`
 apriltag-sys = "^0.1.2"
 ```
 
+### Specifying how to compile and link the apriltag C library.
+
+There are currently three options to specify how apriltag-sys will compile and
+link the apriltag C library. These are specified by setting the
+`APRILTAG_SYS_METHOD` environment variable to one of the following values:
+
+- `pkg-config` (default) - This will use pkg-config.
+- `raw,static` - The environment variable `APRILTAG_SRC` must be set to a
+  directory with the April Tag C library source code. The .c files will be
+  compiled by directly calling the C compiler and statically linked.
+- `cmake,dynamic` - The environment variable `APRILTAG_SRC` must be set to a
+  directory with the April Tag C library source code. The cmake command will be
+  invoked to call the C compiler and the resulting library will be dynamically
+  linked.
+
 ## License
 
 BSD-2-Clause. Please see [license file](LICENSE).

--- a/build.rs
+++ b/build.rs
@@ -42,7 +42,7 @@ fn get_source_method() -> SrcMethod {
             SrcMethod::Cmake(path.into())
         } else {
             // Default if APRILTAG_SRC is set
-            SrcMethod::Cmake(src.into())
+            SrcMethod::RawStatic(src.into())
         }
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -16,33 +16,70 @@ lazy_static! {
     };
 }
 
-fn main() {
+enum SrcMethod {
+    Cmake(PathBuf),
+    RawStatic(PathBuf),
+    PkgConfig,
+}
+
+fn get_source_method() -> SrcMethod {
+    let src: Option<_> = std::env::var_os("APRILTAG_SRC");
+    let src: Option<String> = src.map(|s| s.into_string().unwrap());
+
+    if src.as_ref().filter(|s| s.len() > 0).is_none() {
+        // APRILTAG_SRC was not set or was empty string.
+        SrcMethod::PkgConfig
+    } else {
+        let src = src.unwrap(); // Above check says this won't fail.
+
+        if src.starts_with("RAW=") {
+            // If APRILTAG_SRC is "RAW=<path>"
+            let path = &src[4..];
+            SrcMethod::RawStatic(path.into())
+        } else if src.starts_with("CMAKE=") {
+            // If APRILTAG_SRC is "CMAKE=<path>"
+            let path = &src[5..];
+            SrcMethod::Cmake(path.into())
+        } else {
+            // Default if APRILTAG_SRC is set
+            SrcMethod::Cmake(src.into())
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Error {}
+
+impl From<glob::PatternError> for Error {
+    fn from(_: glob::PatternError) -> Error {
+        Error {}
+    }
+}
+
+impl From<glob::GlobError> for Error {
+    fn from(_: glob::GlobError) -> Error {
+        Error {}
+    }
+}
+
+fn main() -> Result<(), Error> {
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rerun-if-env-changed=APRILTAG_SRC");
 
+    #[allow(unused_variables)]
+    let clang_args = match get_source_method() {
+        SrcMethod::Cmake(src_path) => build_cmake(src_path),
+        SrcMethod::RawStatic(sdk_path) => build_raw_static(sdk_path)?,
+        SrcMethod::PkgConfig => {
+            // check if apriltag is available on system
+            let _ = pkg_config::probe_library("apriltag").unwrap();
+            vec![]
+        }
+    };
+
     #[cfg(feature = "buildtime-bindgen")]
     {
-        let clang_args = match std::env::var_os("APRILTAG_SRC") {
-            Some(src_path) => {
-                // build apriltag from source
-                let dst = build_source(src_path);
-                let include_dir = dst.join("include");
-                let lib_dir = dst.join("lib");
-                println!("cargo:rustc-link-search=native={}", lib_dir.display());
-
-                vec![
-                    format!("-I{}", include_dir.display()),
-                    format!("-L{}", lib_dir.display()),
-                ]
-            }
-            None => {
-                // check if apriltag is available on system
-                let _ = pkg_config::probe_library("apriltag").unwrap();
-                vec![]
-            }
-        };
-
-        let builder = bindgen::Builder::default()
+        let bindgen_builder = bindgen::Builder::default()
             .header("wrapper.h")
             .parse_callbacks(Box::new(bindgen::CargoCallbacks))
             .whitelist_type("apriltag_.*")
@@ -65,8 +102,10 @@ fn main() {
             .whitelist_function("image_u8x4_.*")
             .whitelist_function("zarray_.*")
             .whitelist_function("matd_.*");
-        let builder = builder.clang_args(clang_args);
-        let bindings = builder.generate().expect("Unable to generate bindings");
+        let bindgen_builder = bindgen_builder.clang_args(clang_args);
+        let bindings = bindgen_builder
+            .generate()
+            .expect("Unable to generate bindings");
 
         let bindings_path = MANIFEST_DIR.join("bindings").join("bindings.rs");
         std::fs::create_dir_all(bindings_path.parent().unwrap()).unwrap();
@@ -75,17 +114,64 @@ fn main() {
             .expect("Couldn't write bindings!");
     }
 
-    println!("cargo:rustc-link-lib=apriltag");
+    Ok(())
 }
 
-#[cfg(feature = "buildtime-bindgen")]
-fn build_source<P>(src_path: P) -> PathBuf
+/// Use cmake to build April Tags as a shared library.
+fn build_cmake<P>(src_path: P) -> Vec<String>
 where
     P: AsRef<Path>,
 {
+    println!("cargo:rustc-link-lib=apriltag");
+
     let build_dir = OUT_DIR.join("cmake_build");
     std::fs::create_dir_all(&build_dir).unwrap();
 
     let dst = cmake::Config::new(src_path).out_dir(build_dir).build();
-    dst
+
+    let include_dir = dst.join("include");
+    let lib_dir = dst.join("lib");
+    println!("cargo:rustc-link-search=native={}", lib_dir.display());
+
+    vec![
+        format!("-I{}", include_dir.display()),
+        format!("-L{}", lib_dir.display()),
+    ]
+}
+
+/// Build April Tags source by passing all .c files and compiling static lib.
+fn build_raw_static(sdk_path: PathBuf) -> Result<Vec<String>, Error> {
+    let inc_dir = sdk_path.clone();
+
+    let mut compiler = cc::Build::new();
+
+    // add files in base SDK dir
+    let mut c_files = sdk_path.clone();
+    c_files.push("*.c");
+    let glob_pattern = c_files.to_str().unwrap();
+    let paths = glob::glob_with(glob_pattern, glob::MatchOptions::new())?;
+    for path in paths {
+        let path = path?;
+        let path_str = path.display().to_string();
+        if path_str.ends_with("apriltag_pywrap.c") {
+            continue;
+        }
+        compiler.file(&path);
+    }
+
+    // add files in base/common SDK dir
+    let mut c_files = sdk_path.clone();
+    c_files.push("common");
+    c_files.push("*.c");
+    let glob_pattern = c_files.to_str().unwrap();
+    let paths = glob::glob_with(glob_pattern, glob::MatchOptions::new())?;
+    for path in paths {
+        compiler.file(&path?);
+    }
+
+    compiler.include(&inc_dir);
+    compiler.extra_warnings(false);
+    compiler.compile("apriltags");
+
+    Ok(vec![])
 }


### PR DESCRIPTION
This will allow building the april tags library from source into a statically linked library. There are two advantages for my use case. First, there is no need to distribute and install the april tags dynamic library. Second, the cmake binary does not need to be installed at build time.