### PR TITLE
git submodule. 'pkg-config-then-static' method.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "apriltag-src"]
+	path = apriltag-src
+	url = https://github.com/AprilRobotics/apriltag

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ apriltag-sys = "^0.1.2"
 
 ### Specifying how to compile and link the apriltag C library.
 
-There are currently three options to specify how apriltag-sys will compile and
+There are currently four options to specify how apriltag-sys will compile and
 link the apriltag C library. These are specified by setting the
 `APRILTAG_SYS_METHOD` environment variable to one of the following values:
 
-- `pkg-config` (default) - This will use pkg-config.
+- `pkg-config-then-static` (default) - This will try pkg-config first, then
+   will fallback to `raw,static`.
+- `pkg-config` - This will use pkg-config. Panic upon failure.
 - `raw,static` - The environment variable `APRILTAG_SRC` must be set to a
   directory with the April Tag C library source code. The .c files will be
   compiled by directly calling the C compiler and statically linked.
@@ -27,6 +29,10 @@ link the apriltag C library. These are specified by setting the
   directory with the April Tag C library source code. The cmake command will be
   invoked to call the C compiler and the resulting library will be dynamically
   linked.
+
+The location of the apriltag source is specified by the `APRILTAG_SRC`
+environment variable. If this is not set, a local git submodule checkout of the
+apriltag source will be used.
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -20,30 +20,28 @@ enum SrcMethod {
     Cmake(PathBuf),
     RawStatic(PathBuf),
     PkgConfig,
+    PkgConfigThenStatic(PathBuf),
 }
 
 fn get_source_method() -> SrcMethod {
-    let src = std::env::var_os("APRILTAG_SRC");
+    let src = std::env::var_os("APRILTAG_SRC")
+        .map(PathBuf::from)
+        .unwrap_or(PathBuf::from("apriltag-src")); // git submodule checks this out
     let method: Option<String> = std::env::var_os("APRILTAG_SYS_METHOD").map(|s| {
         s.into_string()
             .expect("If set, APRILTAG_SYS_METHOD environment variable must be UTF-8 string.")
     });
 
     let method: String = match method {
-        None => "pkg-config".to_string(), // This is the default.
+        None => "pkg-config-then-static".to_string(), // This is the default.
         Some(s) => s,
     };
 
     match method.as_str() {
         "pkg-config" => SrcMethod::PkgConfig,
-        "raw,static" => SrcMethod::RawStatic(
-            src.expect("APRILTAG_SRC environment variable must be set")
-                .into(),
-        ),
-        "cmake,dynamic" => SrcMethod::Cmake(
-            src.expect("APRILTAG_SRC environment variable must be set")
-                .into(),
-        ),
+        "pkg-config-then-static" => SrcMethod::PkgConfigThenStatic(src),
+        "raw,static" => SrcMethod::RawStatic(src),
+        "cmake,dynamic" => SrcMethod::Cmake(src),
         _ => {
             panic!(
                 "The APRILTAG_SYS_METHOD was not recognized. See README.md of the \
@@ -69,6 +67,8 @@ impl From<glob::GlobError> for Error {
 }
 
 fn main() -> Result<(), Error> {
+    use SrcMethod::*;
+
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rerun-if-env-changed=APRILTAG_SRC");
     println!("cargo:rerun-if-env-changed=APRILTAG_SYS_METHOD");
@@ -76,12 +76,20 @@ fn main() -> Result<(), Error> {
     // Detect which method to use.
     #[allow(unused_variables)]
     let clang_args = match get_source_method() {
-        SrcMethod::Cmake(src_path) => build_cmake(src_path),
-        SrcMethod::RawStatic(sdk_path) => build_raw_static(sdk_path)?,
-        SrcMethod::PkgConfig => {
+        Cmake(src_path) => build_cmake(src_path),
+        RawStatic(sdk_path) => build_raw_static(sdk_path)?,
+        other => {
             // check if apriltag is available on system
-            let _ = pkg_config::probe_library("apriltag").unwrap();
-            vec![]
+            match pkg_config::probe_library("apriltag") {
+                Ok(_) => vec![],
+                Err(e) => {
+                    if let PkgConfigThenStatic(sdk_path) = other {
+                        build_raw_static(sdk_path)?
+                    } else {
+                        panic!("pkg-config failed: {}", e);
+                    }
+                }
+            }
         }
     };
 

--- a/build.rs
+++ b/build.rs
@@ -27,15 +27,12 @@ fn get_source_method() -> SrcMethod {
     let src = std::env::var_os("APRILTAG_SRC")
         .map(PathBuf::from)
         .unwrap_or(PathBuf::from("apriltag-src")); // git submodule checks this out
-    let method: Option<String> = std::env::var_os("APRILTAG_SYS_METHOD").map(|s| {
-        s.into_string()
-            .expect("If set, APRILTAG_SYS_METHOD environment variable must be UTF-8 string.")
-    });
-
-    let method: String = match method {
-        None => "pkg-config-then-static".to_string(), // This is the default.
-        Some(s) => s,
-    };
+    let method: String = std::env::var_os("APRILTAG_SYS_METHOD")
+        .map(|s| {
+            s.into_string()
+                .expect("If set, APRILTAG_SYS_METHOD environment variable must be UTF-8 string.")
+        })
+        .unwrap_or("pkg-config-then-static".to_string()); // This is the default
 
     match method.as_str() {
         "pkg-config" => SrcMethod::PkgConfig,


### PR DESCRIPTION
Two major changes here:

1) If no APRILTAG_SRC environment variable is specified, use a local
   checkout, made with git submodule, of the apriltag library. Most CI
   systems do recursive checkouts, so this gets us the apriltag source
   without directly including it and without much extra work.
2) Implement a new `SrcMethod`, namely the variant
   `PkgConfigThenStatic`. This becomes the new default. The idea is that
   pkg-config is tried and, if that fails, to use the static build
   approach. Combined with point 1 above, this should result in a robust
   approach that also works on https://docs.rs.

Points 1 and 2 above were inspired by the lzma-sys crate by Alex
Crichton. (See
https://github.com/alexcrichton/xz2-rs/tree/052668eb55231bf8642449c42321522ec46b6640/lzma-sys.)