### PR TITLE
Allow builds under Windows

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,0 +1,29 @@
+name: build_windows
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  default:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: Install the shim for pthread
+      uses: lukka/run-vcpkg@main
+      id: vcpkg
+      with:
+        vcpkgArguments: 'pthread'
+        vcpkgTriplet: 'x64-windows-static'
+        vcpkgDirectory: '${{runner.workspace}}/vcpkg'
+        vcpkgGitCommitId: '57bd7102d9fd880daa1b0958692294c4a125f6d8'
+    - name: Check linking
+      run: cargo test
+      env:
+        APRILTAG_SYS_WINDOWS_PTHREAD_INCLUDE_DIR: '${{steps.vcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT}}\installed\x64-windows-static\include'
+        APRILTAG_SYS_WINDOWS_PTHREAD_STATIC_LIB: '${{steps.vcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT}}\installed\x64-windows-static\lib\pthreadVC3.lib'
+

--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ The location of the apriltag source is specified by the `APRILTAG_SRC`
 environment variable. If this is not set, a local git submodule checkout of the
 apriltag source will be used.
 
+#### Building under Windows
+
+Strictly speaking, using apriltag on Microsoft Windows is not *officially* supported by the developers. In practice, the library works well even on this operating system. 
+The only additional complexity emerges during the building process. The C library requires *pthread.h* not shipped with Windows by default.
+Consequently, different shims like [pthreads4w](https://sourceforge.net/projects/pthreads4w/) and [Pthreads-w32](https://www.sourceware.org/pthreads-win32/) are required.
+If one of them is installed, setting the environment variables `APRILTAG_SYS_WINDOWS_PTHREAD_INCLUDE_DIR` to its include directory and `APRILTAG_SYS_WINDOWS_PTHREAD_STATIC_LIB` to the compiled static library allows a successful build under Windows with `APRILTAG_SYS_METHOD=raw,static`.
+
+As an example using [vcpkg](https://github.com/microsoft/vcpkg), building under Windows consists of three additional steps:
+1. Install the shim using `vcpkg install pthread:x64-windows-static`
+2. Specify the include directoy (here in PowerShell): `$env:APRILTAG_SYS_WINDOWS_PTHREAD_INCLUDE_DIR="%SPECIFY VCPKG DIRECTORY HERE%\installed\x64-windows-static\include"`
+3. Specify the path to the static library (again in PowerShell): `$env:APRILTAG_SYS_WINDOWS_PTHREAD_STATIC_LIB="%SPECIFY VCPKG DIRECTORY HERE%\installed\x64-windows-static\lib\pthreadVC3.lib""`
+
+Some shims require `winmm.dll` for high-precision timing shipped by default with all Windows installations. If this linking is not necessary, it can be omitted by setting `APRILTAG_SYS_WINDOWS_NO_WINMM=1`.
+
 ## License
 
 BSD-2-Clause. Please see [license file](LICENSE).


### PR DESCRIPTION
While apriltag on Microsoft Windows is not *officially* supported by the developers, it works fine in practice. This commits add the ability to build this crate under Windows by specifying a shim for the required `pthreads` via environment variables, document those in the README, and add a corresponding test for CI. Currently, the building process fails with a hardly interpretable "cl.exe" error on this operating system.

